### PR TITLE
イベント詳細の固定値を修正

### DIFF
--- a/app/views/events/_event.html.slim
+++ b/app/views/events/_event.html.slim
@@ -5,10 +5,10 @@ li.event_item
     .event_detail_content
       .event_content_top
         .event_content_title
-          a(href="https://vscode.connpass.com/event/184441" target="_blank")
+          a(href="#{event[:detail].url}" target="_blank")
             = event[:detail].title
         .event_content_thumbnail
-          = image_tag "https://placeimg.com/320/240/tech"
+          = image_tag "#{event[:detail].banner}"
       .event_content_bottom
         .event_content_description
           = event[:detail].description

--- a/app/views/events/_event_held.html.slim
+++ b/app/views/events/_event_held.html.slim
@@ -1,5 +1,5 @@
 .event_held
   .event_date
-    | 9/22
+    = event.started_at.strftime('%m/%d')
   .event_start
     | 開催


### PR DESCRIPTION
# 概要

イベント詳細の固定値を動的に設定する。

* バナー画像
* リンク先のURL
* イベントの開始日