### PR TITLE
フォロー取得のクローラのループ処理のsleepが動いていない不具合を修正

### DIFF
--- a/lib/crawler/following_crawler.rb
+++ b/lib/crawler/following_crawler.rb
@@ -49,9 +49,9 @@ class FollowingCrawler < DaemonSpawn::Base
         }
       end
       Friendship.insert_all(inserted_friendships)
+    ensure
+      sleep 5 
     end
-  ensure
-    sleep 5
   end
 
   def stop


### PR DESCRIPTION
# 概要

フォロー取得のクローラのループ処理のsleepの実装箇所がおかしいため、loopのブロック文の最後の
ensure文でsleepするように修正する。