### PR TITLE
イベント一覧画面のバグ対応

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -252,11 +252,14 @@ body {
           align-items: center;
         }
         .friend_icon {
-          width: 50px;
-          height: 50px;
-          margin-right: 5px;
-          border-radius: 50%;
           overflow: hidden;
+          padding-right: 5px;
+
+          img {
+            width: 50px;
+            height: 50px;
+            border-radius: 50%;
+          }
         }
       }
     }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -226,49 +226,6 @@ body {
         }
 
       }
-
-      .friends_list {
-        width: 100%;
-        height: 80px;
-        display: flex;
-        flex-direction: row;
-        align-items: center;
-        justify-content: flex-start;
-        padding: 20px 5px;
-        box-sizing: border-box;
-        .friend_number {
-          width: 50px;
-          height: 50px;
-          border: 1px solid #ccc;
-          border-radius: 5px;
-          background-color: #f3f4f7;
-          font-size: 1.5em;
-          font-weight: bold;
-          margin-left: 10px;
-          margin-right: 10px;
-          display: flex;
-          flex-direction: row;
-          justify-content: center;
-          align-items: center;
-        }
-        .friend_icon {
-          overflow: hidden;
-          padding-right: 5px;
-
-          img {
-            width: 50px;
-            height: 50px;
-            border-radius: 50%;
-          }
-
-          .noimage {
-            width: 50px;
-            height: 50px;
-            border-radius: 50%;
-            background-color: #efe9e5;
-          }
-        }
-      }
     }
 
     .event_list_footer {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -260,6 +260,13 @@ body {
             height: 50px;
             border-radius: 50%;
           }
+
+          .noimage {
+            width: 50px;
+            height: 50px;
+            border-radius: 50%;
+            background-color: #efe9e5;
+          }
         }
       }
     }

--- a/app/javascript/event_sort_filter.vue
+++ b/app/javascript/event_sort_filter.vue
@@ -8,10 +8,10 @@
         form(action="/" method="GET" id="js-sort-filter-form")
           .event-modal-header
             .event-modal-left
-              | Sort
+              | Sort by
             .event-modal-center
             .event-modal-right
-              | Filter
+              | Filter by
           .event-modal-content
               .event-modal-left.event-modal-sort
                 select(v-model="selectedSortCondition" @change="selectedSortConditionChanged($event)" name="sort")

--- a/app/javascript/friends_list.vue
+++ b/app/javascript/friends_list.vue
@@ -209,13 +209,51 @@ export default {
     }
   }
 
-  .friend_number {
-    cursor: pointer;
-  }
+  .friends_list {
+    width: 100%;
+    height: 80px;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: flex-start;
+    padding: 20px 5px;
+    box-sizing: border-box;
 
-  .friend_icon {
-    cursor: pointer;
-  }
+    .friend_number {
+      width: 50px;
+      height: 50px;
+      border: 1px solid #ccc;
+      border-radius: 5px;
+      background-color: #f3f4f7;
+      font-size: 1.5em;
+      font-weight: bold;
+      margin-left: 10px;
+      margin-right: 10px;
+      display: flex;
+      flex-direction: row;
+      justify-content: center;
+      align-items: center;
+      cursor: pointer;
+    }
 
+    .friend_icon {
+      overflow: hidden;
+      padding-right: 5px;
+      cursor: pointer;
+
+      img {
+        width: 50px;
+        height: 50px;
+        border-radius: 50%;
+      }
+
+      .noimage {
+        width: 50px;
+        height: 50px;
+        border-radius: 50%;
+        background-color: #efe9e5;
+      }
+    }
+  }
 
 </style>

--- a/app/javascript/friends_list.vue
+++ b/app/javascript/friends_list.vue
@@ -129,7 +129,7 @@ export default {
   .event-modal-container {
     max-width: 30em;
     min-width: 30em;
-    height: 30em;
+    height: auto;
 
     .tweet_list {
       width: 100%;

--- a/app/javascript/friends_list.vue
+++ b/app/javascript/friends_list.vue
@@ -6,7 +6,7 @@
     .friend_icon(v-for="(userId, index) in userIdsArray" :key="`placeholder-${index}`" v-show="friends.length == 0")
       img(src="https://dummyimage.com/100x100/8db9ca/fff.png")
       | {{ userIds }}
-    .friend_icon(v-for="(friend, index) in friends" :key="`frineds-${index}`" v-show="friends.length > 0")
+    .friend_icon(v-for="(friend, index) in displayable_friends" :key="`frineds-${index}`" v-show="friends.length > 0")
       a(:href="friend | friend_screen_name" target="_blank")
         img(:src="friend.profile_image")
 
@@ -41,7 +41,8 @@ export default {
     return {
       modal: false,
       tweets: [],
-      friends: [] 
+      friends: [],
+      maxFriendsLength: 12
     }
   },
   computed: {
@@ -50,6 +51,13 @@ export default {
     },
     userIdsArray() {
       return this.userIds.split(",")
+    },
+    displayable_friends() {
+      if (this.friends.length > this.maxFriendsLength) {
+        return this.friends.slice(0, this.maxFriendsLength)
+      }
+
+      return this.friends
     }
   },
   methods: {

--- a/app/javascript/friends_list.vue
+++ b/app/javascript/friends_list.vue
@@ -5,7 +5,6 @@
     
     .friend_icon(v-for="(userId, index) in userIdsArray" :key="`placeholder-${index}`" v-show="friends.length == 0")
       img(src="https://dummyimage.com/100x100/8db9ca/fff.png")
-      | {{ userIds }}
     .friend_icon(v-for="(friend, index) in displayable_friends" :key="`frineds-${index}`" v-show="friends.length > 0")
       a(:href="friend | friend_screen_name" target="_blank")
         img(:src="friend.profile_image")

--- a/app/javascript/friends_list.vue
+++ b/app/javascript/friends_list.vue
@@ -4,7 +4,7 @@
       | {{ friendsNumber }}
     
     .friend_icon(v-for="(userId, index) in userIdsArray" :key="`placeholder-${index}`" v-show="friends.length == 0")
-      img(src="https://dummyimage.com/100x100/8db9ca/fff.png")
+      .noimage
     .friend_icon(v-for="(friend, index) in displayable_friends" :key="`frineds-${index}`" v-show="friends.length > 0")
       a(:href="friend | friend_screen_name" target="_blank")
         img(:src="friend.profile_image")

--- a/app/javascript/loading.vue
+++ b/app/javascript/loading.vue
@@ -7,7 +7,7 @@
 
 .loader-wrapper {
   width: 100%;
-  height: 100%;
+  height: 15em;
   display: flex;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
# 概要

* イベント一覧画面のバグを修正する

# チェックリスト
* [x] 友達一覧の画面の高さをコンテンツに合わせる
* [x] 仮のplaceholderの画像を変更する
* [x] 友達一覧画像の表示崩れを修正する
* [x] 友達一覧に表示する最大数を制御する
* [x] 絞り込みにラベルをSort byとFilter byに変更