### PR TITLE
Axiosの認証APIのURLをパス指定に変更

### DIFF
--- a/front/components/HomeTwitterLogin.vue
+++ b/front/components/HomeTwitterLogin.vue
@@ -29,7 +29,7 @@ export default defineComponent({
         const user = result.user
         if (token == null || secret == null || user == null) return
         const id_token = await user.getIdToken()
-        root.$axios.post("http://localhost:3000/api/sessions", {
+        root.$axios.post("/api/sessions", {
           access_token: token,
           access_token_secret: secret,
           token: id_token


### PR DESCRIPTION
# 概要

Axiosの認証APIのURLが絶対URLになっているので、@nuxtjs/proxyを使ったパス指定に変更する