### PR TITLE
イベントサイトの固定リンクを修正

### DIFF
--- a/front/components/Event.vue
+++ b/front/components/Event.vue
@@ -8,7 +8,7 @@ li.event_item
     .event_detail_content
       .event_content_top
         .event_content_title
-          a(href="/" target="_blank")
+          a(:href="eventInfo.event.url" target="_blank")
             | {{ eventInfo.event.title }}
         .event_content_thumbnail
           img(:src="eventInfo.event.banner")


### PR DESCRIPTION
## 概要

イベントサイトの外部リンクが固定のlocalhostのリンクになっているので、イベントサイトの正規のURLに遷移させる