### PR TITLE
ホーム画面のコンテンツのレイアウト調整

### DIFF
--- a/front/pages/home.vue
+++ b/front/pages/home.vue
@@ -59,6 +59,11 @@ export default defineComponent({
   }
 }
 
+.home_container {
+  max-width: 50rem;
+  margin: 0 auto;
+} 
+
 .footer {
   padding: 5px;
   background-color: #efe9e5;


### PR DESCRIPTION
## 概要

ホーム画面のコンテンツが全体に広がっているため、中央寄席でマージン調整を行う。