### PR TITLE
未ログイン時のhome以外のURLアクセスの制御

### DIFF
--- a/front/middleware/auth.ts
+++ b/front/middleware/auth.ts
@@ -2,11 +2,7 @@ import { defineNuxtMiddleware } from "@nuxtjs/composition-api"
 import "firebase/auth"
 
 export default defineNuxtMiddleware(({ store, route, redirect }) => {
-  if (!store.state.auth && route.name === "events") {
-    return redirect("/home")
-  }
-
-  if (!store.state.auth && route.name === "index") {
+  if (!store.state.auth && route.name !== "home") {
     return redirect("/home")
   }
 


### PR DESCRIPTION
# 概要

未ログイン時にルートURLにアクセスした場合に存在しないルートを表示する。
そのため、homeパス以外にアクセスした場合は、homeパスにリダイレクトさせる。