### PR TITLE
イベント一覧画面の不具合修正

### DIFF
--- a/api/app/controllers/api/events_controller.rb
+++ b/api/app/controllers/api/events_controller.rb
@@ -10,7 +10,6 @@ class Api::EventsController < Api::BaseController
     @data = @events.map.with_index do |event, index|
       friend_user_ids = event.tweets.pluck(:user_id).uniq.select do |user_id|
         following.include?(user_id)
-        true
       end
       {
         event: event,

--- a/api/app/models/concerns/event_sort_filterable.rb
+++ b/api/app/models/concerns/event_sort_filterable.rb
@@ -10,7 +10,7 @@ module EventSortFilterable
     when "created_order"
       "MIN(tweets.tweeted_at) ASC"
     when "closeness_order"
-      "started_at DESC"
+      "started_at ASC"
     else
       "count(distinct tweets.user_id) DESC"
     end

--- a/front/components/Event.vue
+++ b/front/components/Event.vue
@@ -28,7 +28,8 @@ import {
   onMounted,
   reactive,
   toRefs,
-  computed
+  computed,
+  watch
 } from "@nuxtjs/composition-api"
 import sanitizeHtml from "sanitize-html"
 
@@ -91,12 +92,23 @@ export default defineComponent({
       return logo
     }
 
+    const updateState = (eventInfo: Record<string, any>) => {
+      if (!eventInfo) return
+      state.eventId = eventInfo.event.id
+      state.userIds = eventInfo.extra.user_ids
+      state.friendsNumber = eventInfo.extra.friends_number
+      state.startedAt = eventInfo.event.started_at
+    }
+
+    watch(
+      () => props.eventInfo,
+      async (newValue) => {
+        updateState(newValue)
+      }
+    )
+
     onMounted(() => {
-      if (!props.eventInfo) return
-      state.eventId = props.eventInfo.event.id
-      state.userIds = props.eventInfo.extra.user_ids
-      state.friendsNumber = props.eventInfo.extra.friends_number
-      state.startedAt = props.eventInfo.event.started_at
+      updateState(props.eventInfo)
     })
 
     return {

--- a/front/components/FriendsList.vue
+++ b/front/components/FriendsList.vue
@@ -38,7 +38,8 @@ import {
   computed,
   reactive,
   toRefs,
-  onMounted
+  onMounted,
+  watch
 } from "@nuxtjs/composition-api"
 import firebase from "firebase/app"
 import "firebase/auth"
@@ -141,10 +142,10 @@ export default defineComponent({
       return `https://twitter.com/${value.screen_name}`
     }
 
-    onMounted(async () => {
+    const updateFriends = async (userIds) => {
       const idToken = await firebase.auth().currentUser.getIdToken()
       root.$axios
-        .get(`/api/friendships.json?user_ids=${props.userIds}`, {
+        .get(`/api/friendships.json?user_ids=${userIds}`, {
           headers: {
             Authorization: `Bearer ${idToken}`
           }
@@ -155,7 +156,23 @@ export default defineComponent({
         .catch((error) => {
           console.log(`error: ${error}`)
         })
-    })
+    }
+
+    watch(
+      () => props.friendsNumber,
+      (newValue) => {
+        state.friendsNumber = newValue
+      }
+    )
+
+    watch(
+      () => props.userIds,
+      (newValue, oldValue) => {
+        if (newValue !== oldValue && newValue !== "") {
+          updateFriends(newValue)
+        }
+      }
+    )
 
     return {
       ...toRefs(state),


### PR DESCRIPTION
## 概要

以下の不具合を修正
* イベントの友達一覧にフォローしていないユーザーが含まれる
* 開催が近い順のソート順が逆になっている
* ソート条件切り替えても、イベント一覧や友達一覧が更新されない