### PR TITLE
VSCode Remote Containerの設定を追加

### DIFF
--- a/api/.devcontainer.json
+++ b/api/.devcontainer.json
@@ -1,0 +1,23 @@
+{
+  "name": "rails devcontainer",
+  "dockerComposeFile": "../docker-compose.yml",
+  "service": "api",
+  "remoteUser": "postgres",
+  "workspaceFolder": "/app",
+  "settings": {
+    "terminal.integrated.shell.linux": "/bin/bash",
+    "sqltools.connections": [{
+      "name": "Container database",
+      "driver": "PostgreSQL",
+      "previewLimit": 50,
+      "server": "localhost",
+      "port": 5432,
+      "database": "eventfollow_development",
+      "username": "postgres",
+      "password": "postgres"
+    }]
+  },
+
+  // Add the IDs of extensions you want installed when the container is created.
+  "extensions": ["rebornix.Ruby", "mtxr.sqltools", "mtxr.sqltools-driver-pg"]
+}

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -2,7 +2,7 @@ FROM ruby:3.0.0-alpine
 
 ARG WORKDIR
 
-ENV RUNTIME_PACKAGES="linux-headers libxml2-dev make gcc libc-dev nodejs tzdata postgresql-dev postgresql git yarn"
+ENV RUNTIME_PACKAGES="linux-headers libxml2-dev make gcc libc-dev nodejs tzdata postgresql-dev postgresql git yarn bash bash-completion"
 ENV DEV_PACKAGES="build-base curl-dev"
 ENV HOME=/${WORKDIR}
 ENV LANG=C.UTF-8

--- a/front/.devcontainer.json
+++ b/front/.devcontainer.json
@@ -1,0 +1,9 @@
+{
+  "name": "front devcontainer",
+  "dockerComposeFile": "../docker-compose.yml",
+  "service": "front",
+  "workspaceFolder": "/app",
+  "settings": {
+    "terminal.integrated.shell.linux": "/bin/bash"
+  }
+}

--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -4,6 +4,7 @@ ARG WORKDIR
 ARG CONTAINER_PORT
 ARG API_URL
 
+ENV RUNTIME_PACKAGES="bash bash-completion"
 ENV HOME=/${WORKDIR} 
 ENV LANG=C.UTF-8 
 ENV TZ=Asia/Tokyo 
@@ -11,6 +12,10 @@ ENV HOST=0.0.0.0
 ENV API_URL=${API_URL}
   
 WORKDIR ${HOME}
+
+RUN apk update && \
+		apk upgrade && \
+		apk add --no-cache ${RUNTIME_PACKAGES}
 
 COPY package.json ./
 COPY yarn.lock ./


### PR DESCRIPTION
# 概要

VSCode Remote ContainerでDockerコンテナを利用できるように、Nuxt.jsとRails用のdevcontainer.jsonを追加する。

# 関連issue

#153 