### PR TITLE
HerokuのNuxtアプリのコールドスタートの解消

### DIFF
--- a/.github/workflows/wakeup_polling.yml
+++ b/.github/workflows/wakeup_polling.yml
@@ -1,0 +1,15 @@
+name: wakeup front
+
+on:
+  schedule:
+    - cron: '0,20,40 * * * *'
+  push:
+    branches:
+      - master
+
+jobs:
+  wakeup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: wakeup EVENT_FOLLOW_FRONT_URL
+        run: curl --head --silent --show-error ${{ secrets.EVENT_FOLLOW_FRONT_URL }}


### PR DESCRIPTION
# 概要

Nuxt.jsのアプリが無料版でコールドスタートするので、GitHub Actionsを使って定期的にポーリングする。

# 関連issue

#158 