### PR TITLE
docker環境のrailsのデバッグ

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
 
   api:
     container_name: event_api
+    tty: true
+    stdin_open: true
     build:
       context: ./api
       args:


### PR DESCRIPTION
# 概要

docker環境のrailsでbyebugを使えないので、docker-compose.ymlにttyとstdinの設定を追加する

# 関連issue

#198 