### PR TITLE
Github Actionsのワークフローの変更

### DIFF
--- a/.github/workflows/api_deploy.yml
+++ b/.github/workflows/api_deploy.yml
@@ -1,33 +1,33 @@
-name: Deploy to Heroku (front)
+name: Deploy to Heroku (api)
 
 on:
   push:
     branches:
       - main
     paths:
-      - "front/**"
-      - ".github/workflows/front.yml"
+      - "api/**"
+      - ".github/workflows/api_deploy.yml"
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.0.0
-      - name: Add front remote origin
-        run: git remote add heroku-front https://heroku:${{ secrets.HEROKU_API_TOKEN }}@git.heroku.com/${{ secrets.HEROKU_FRONT_APP_NAME }}.git
-      - name: Deploy front to Heroku
-        run: git push heroku-front `git subtree split --prefix front ${GITHUB_REF}`:refs/heads/master --force
+      - name: Add api remote origin
+        run: git remote add heroku-api https://heroku:${{ secrets.HEROKU_API_TOKEN }}@git.heroku.com/${{ secrets.HEROKU_API_APP_NAME }}.git
+      - name: Deploy api to Heroku
+        run: git push heroku-api `git subtree split --prefix api ${GITHUB_REF}`:refs/heads/master --force
       - name: Slack notification on failure
         if: failure()
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_COLOR: danger
-          SLACK_TITLE: front deployment failure
+          SLACK_TITLE: api deployment failure
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
       - name: Slack notification on success
         if: success()
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_COLOR: good
-          SLACK_TITLE: front deployment success
+          SLACK_TITLE: api deployment success
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/api_lint.yml
+++ b/.github/workflows/api_lint.yml
@@ -8,7 +8,7 @@ on:
       - "docker-compose.yml"
 
 jobs:
-  rubocop:
+  reviewdog_rubocop:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -18,5 +18,5 @@ jobs:
           rubocop_version: 1.8.1
           github_token: ${{ secrets.GITHUB_TOKEN }}
           rubocop_flags: --config api/.rubocop.yml api/
-          reporter: github-pr-review
+          reporter: github-pr-check
 

--- a/.github/workflows/front_deploy.yml
+++ b/.github/workflows/front_deploy.yml
@@ -1,33 +1,33 @@
-name: Deploy to Heroku (api)
+name: Deploy to Heroku (front)
 
 on:
   push:
     branches:
       - main
     paths:
-      - "api/**"
-      - ".github/workflows/api.yml"
+      - "front/**"
+      - ".github/workflows/front_deploy.yml"
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.0.0
-      - name: Add api remote origin
-        run: git remote add heroku-api https://heroku:${{ secrets.HEROKU_API_TOKEN }}@git.heroku.com/${{ secrets.HEROKU_API_APP_NAME }}.git
-      - name: Deploy api to Heroku
-        run: git push heroku-api `git subtree split --prefix api ${GITHUB_REF}`:refs/heads/master --force
+      - name: Add front remote origin
+        run: git remote add heroku-front https://heroku:${{ secrets.HEROKU_API_TOKEN }}@git.heroku.com/${{ secrets.HEROKU_FRONT_APP_NAME }}.git
+      - name: Deploy front to Heroku
+        run: git push heroku-front `git subtree split --prefix front ${GITHUB_REF}`:refs/heads/master --force
       - name: Slack notification on failure
         if: failure()
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_COLOR: danger
-          SLACK_TITLE: api deployment failure
+          SLACK_TITLE: front deployment failure
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
       - name: Slack notification on success
         if: success()
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_COLOR: good
-          SLACK_TITLE: api deployment success
+          SLACK_TITLE: front deployment success
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
# 概要

- [x] api_lint.ymlのジョブをrubocopからreviewdog_rubocopに変更
- [x] api_lint.ymlのreviewdogのreporterをgithub-pr-checkに変更
- [x] api.ymlの名称をapi_deploy.ymlに変更
- [x] front.ymlの名称をfront_deploy.ymlに変更