### PR TITLE
ログイン時にフォロー情報を取得

### DIFF
--- a/api/app/controllers/api/sessions_controller.rb
+++ b/api/app/controllers/api/sessions_controller.rb
@@ -9,6 +9,7 @@ class Api::SessionsController < Api::BaseController
       @user = User.find_or_create_from_auth(payload: payload,
                                             access_token: access_token,
                                             access_token_secret: access_token_secret)
+      FollowingCrawler.new(@user).execute
     else
       @error_message = "認証情報が不正です"
     end

--- a/api/lib/crawler/following_crawler.rb
+++ b/api/lib/crawler/following_crawler.rb
@@ -4,8 +4,12 @@ class FollowingCrawler
   include BaseCrawlable
   include FollowingCrawlable
 
+  def initialize(target_user = nil)
+    @target_user = target_user
+  end
+
   def execute
-    target_user = find_target_user
+    target_user = @target_user || find_target_user
     return unless target_user
 
     users, next_cursor = search_following(target_user)

--- a/api/spec/requests/sessions_spec.rb
+++ b/api/spec/requests/sessions_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe "Sessions", type: :request do
   describe "POST /api/sessions" do
     before do
       setup_jwt_authentication
+      stub_following_crawler
     end
 
     def verify_credentials
@@ -60,5 +61,9 @@ RSpec.describe "Sessions", type: :request do
       expect(login_user.user_token.access_token_secret).to eq dummy_access_token_secret
       expect(response).to have_http_status(200)
     end
+  end
+
+  def stub_following_crawler
+    allow_any_instance_of(FollowingCrawler).to receive(:execute).and_return(nil)
   end
 end


### PR DESCRIPTION
# 概要

初期ログイン時にフォロー情報がないと、イベント情報を表示することができない。
そのため、初期ログイン時にフォロー情報を取得する。

# 関連issue

#181 