### PR TITLE
DockerでRubocopのLintを実行

### DIFF
--- a/api/Gemfile
+++ b/api/Gemfile
@@ -36,6 +36,8 @@ group :development do
   gem "spring"
   gem "faraday_curl"
   gem "spring-commands-rspec"
+  gem "rubocop-rails", require: false
+  gem "rubocop-performance", require: false
 end
 
 group :test do

--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -163,6 +163,9 @@ GEM
     ogp (0.4.0)
       oga (~> 2.15)
     openapi_parser (0.12.1)
+    parallel (1.20.1)
+    parser (3.0.0.0)
+      ast (~> 2.4.1)
     pg (1.2.3)
     puma (5.2.1)
       nio4r (~> 2.0)
@@ -198,6 +201,7 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (~> 1.0)
+    rainbow (3.0.0)
     rake (13.0.3)
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
@@ -205,6 +209,8 @@ GEM
     redis (4.2.5)
     redis-namespace (1.6.0)
       redis (>= 3.0.4)
+    regexp_parser (2.1.1)
+    rexml (3.2.4)
     rspec-core (3.10.1)
       rspec-support (~> 3.10.0)
     rspec-expectations (3.10.1)
@@ -222,9 +228,28 @@ GEM
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
     rspec-support (3.10.2)
+    rubocop (1.11.0)
+      parallel (~> 1.10)
+      parser (>= 3.0.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.2.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.4.1)
+      parser (>= 2.7.1.5)
+    rubocop-performance (1.10.1)
+      rubocop (>= 0.90.0, < 2.0)
+      rubocop-ast (>= 0.4.0)
+    rubocop-rails (2.9.1)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 0.90.0, < 2.0)
     ruby-ll (2.1.2)
       ansi
       ast
+    ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.4)
     sentry-rails (4.2.1)
       rails (>= 5.0)
@@ -255,6 +280,7 @@ GEM
       method_source
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
+    unicode-display_width (2.0.0)
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -286,12 +312,14 @@ DEPENDENCIES
   rack-cors
   rails (~> 6.1.3)
   rspec-rails (~> 4.0.2)
+  rubocop-performance
+  rubocop-rails
   sentry-rails
   sentry-ruby
   skylight
   spring
-  trace_location
   spring-commands-rspec
+  trace_location
   tzinfo-data
 
 RUBY VERSION


### PR DESCRIPTION
# 概要

Docker上でRubocopを実行できなかったので、Gemfileでrubocopを導入する。