### PR TITLE
rspec-railsとskylightのメジャーバージョンを更新

### DIFF
--- a/api/Gemfile
+++ b/api/Gemfile
@@ -19,7 +19,7 @@ gem "kaminari"
 gem "clockwork"
 gem "rack-cors"
 gem "firebase-auth-rails"
-gem "skylight"
+gem "skylight", '~> 5.0'
 gem "sentry-ruby"
 gem "sentry-rails"
 
@@ -27,7 +27,7 @@ group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]
   gem "factory_bot"
   gem "factory_bot_rails"
-  gem "rspec-rails", "~> 4.0.2"
+  gem "rspec-rails", '~> 5.0'
   gem "trace_location"
 end
 

--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -219,10 +219,10 @@ GEM
     rspec-mocks (3.10.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
-    rspec-rails (4.0.2)
-      actionpack (>= 4.2)
-      activesupport (>= 4.2)
-      railties (>= 4.2)
+    rspec-rails (5.0.0)
+      actionpack (>= 5.2)
+      activesupport (>= 5.2)
+      railties (>= 5.2)
       rspec-core (~> 3.10)
       rspec-expectations (~> 3.10)
       rspec-mocks (~> 3.10)
@@ -261,10 +261,8 @@ GEM
     sentry-ruby-core (4.2.2)
       concurrent-ruby
       faraday
-    skylight (4.3.2)
-      skylight-core (= 4.3.2)
-    skylight-core (4.3.2)
-      activesupport (>= 4.2.0)
+    skylight (5.0.0)
+      activesupport (>= 5.2.0)
     spring (2.1.1)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
@@ -311,12 +309,12 @@ DEPENDENCIES
   puma (~> 5.2)
   rack-cors
   rails (~> 6.1.3)
-  rspec-rails (~> 4.0.2)
+  rspec-rails (~> 5.0)
   rubocop-performance
   rubocop-rails
   sentry-rails
   sentry-ruby
-  skylight
+  skylight (~> 5.0)
   spring
   spring-commands-rspec
   trace_location


### PR DESCRIPTION
# 概要

rspec-railsとskylightのgemのメジャーバージョンを5に更新