### PR TITLE
`イベント一覧`のレイアウト調整

### DIFF
--- a/front/components/Event.vue
+++ b/front/components/Event.vue
@@ -204,7 +204,6 @@ export default defineComponent({
 
     .event_detail {
       width: 100%;
-      height: 300px;
       display: flex;
       flex-direction: row;
 
@@ -283,7 +282,6 @@ export default defineComponent({
         .event_content_bottom {
           display: flex;
           flex-direction: column;
-          height: 60%;
           overflow: scroll;
 
           .event_content_description {

--- a/front/components/FriendsList.vue
+++ b/front/components/FriendsList.vue
@@ -289,8 +289,10 @@ export default defineComponent({
     }
     .friend_icon {
       overflow: hidden;
-      padding-right: 5px;
+      margin-right: 5px;
       cursor: pointer;
+      width: 50px;
+      height: 50px;
       img {
         width: 50px;
         height: 50px;
@@ -399,8 +401,10 @@ export default defineComponent({
     }
     .friend_icon {
       overflow: hidden;
-      padding-right: 5px;
+      margin-right: 5px;
       cursor: pointer;
+      width: 30px;
+      height: 30px;
       img {
         width: 30px;
         height: 30px;


### PR DESCRIPTION
# 概要

イベント一覧のイベント詳細の表示崩れを修正する。

# 変更内容

- [x] 友達アイコンの位置調整
- [x] SP版のイベント概要のテキストがスクロールする不具合を修正