### PR TITLE
初回イベント一覧の表示で検索条件付きでAPIをリクエストする

### DIFF
--- a/api/app/controllers/api/events_controller.rb
+++ b/api/app/controllers/api/events_controller.rb
@@ -32,7 +32,9 @@ class Api::EventsController < Api::BaseController
           friends_filter_type: params[:friends])
         user_event_setting.reload
       rescue ArgumentError
-        redirect_to authenticated_root_path
+        # [ArgumentErrorの補足理由]
+        # enumの設定値にない不正な検索条件の値は設定値の更新時にArgumentErrorが発生する。
+        # ArgumentErrorの場合は、デフォルトの検索条件を以降で設定する。
       end
 
       @event_sort_type = user_event_setting.event_sort_type

--- a/front/pages/events.vue
+++ b/front/pages/events.vue
@@ -121,8 +121,14 @@ export default defineComponent({
       state.currentPage = Number(query.value.page)
         ? Number(query.value.page)
         : 1
+      const sortFilterCondition = {
+        sort: query.value.sort,
+        time: query.value.time,
+        friends: query.value.friends
+      }
       const params = {
-        page: state.currentPage
+        page: state.currentPage,
+        ...sortFilterCondition
       }
 
       requestEventAPI(idToken, params)


### PR DESCRIPTION
# 概要

初回イベント一覧の表示で、クエリに検索条件が付与されていても、検索条件が無視された状態になっている。
そのため、クエリに検索条件が付与されている場合は、検索条件付きでイベント一覧のAPIをリクエストするように修正する。