### PR TITLE
fix: ボタンの中の文字が若干上に配置されている [ci skip]

### DIFF
--- a/front/components/HomeTwitterLogin.vue
+++ b/front/components/HomeTwitterLogin.vue
@@ -127,6 +127,9 @@ export default defineComponent({
       padding: 15px 40px;
       border-radius: 10px;
       cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
 
       &::before {
         content: "";
@@ -153,6 +156,9 @@ export default defineComponent({
       padding: 10px 30px;
       border-radius: 10px;
       cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
 
       &::before {
         content: "";


### PR DESCRIPTION
# 関連issue

#378 