### PR TITLE
fix: イベント一覧のイベントが重複するバグを修正

### DIFF
--- a/front/components/EventsContent.vue
+++ b/front/components/EventsContent.vue
@@ -1,8 +1,7 @@
 <template lang="pug">
   div
     ul(v-show="!isEventEmpty")
-      li(v-for="event in events" :key="event.event.id")
-        Event(:eventInfo="event" v-for="event in events" :key="event.event.id")
+      Event(:eventInfo="event" v-for="event in events" :key="event.event.id")
     .no-event(v-show="isEventEmpty")
       | イベントが見つかりません。
 </template>


### PR DESCRIPTION
# 概要

イベント一覧のイベントが重複しているバグを修正する

# 対応内容

イベント一覧を二重ループで表示するロジックになっていたので、liタグのループ処理を削除した。