### PR TITLE
ソート&絞り込みUIのラベルを左寄せに修正

### DIFF
--- a/front/components/EventSortFilter.vue
+++ b/front/components/EventSortFilter.vue
@@ -185,6 +185,7 @@ export default defineComponent({
       .event-modal-sort,
       .event-modal-filter {
         width: calc((100%-1.5em)/2);
+        width: -webkit-calc((100% - 1.5em)/2);
         position: relative;
         display: flex;
         flex-direction: column;

--- a/front/components/EventSortFilter.vue
+++ b/front/components/EventSortFilter.vue
@@ -289,6 +289,9 @@ export default defineComponent({
       .event-modal-sort,
       .event-modal-filter {
         width: 100%;
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
 
         .event-modal-label {
           height: 40%;
@@ -302,6 +305,7 @@ export default defineComponent({
         .event-modal-value {
           height: 60%;
           position: relative;
+          width: 100%;
 
           &::after {
             content: "";


### PR DESCRIPTION
# 概要
SP版のソート＆絞り込みUIのラベルがセンター寄せになっているので、左寄せに修正する