### PR TITLE
Release-20210507

### DIFF
--- a/front/components/Event.vue
+++ b/front/components/Event.vue
@@ -142,6 +142,7 @@ export default defineComponent({
             padding-right: 5px;
             font-family: YakuHanJP, "Hiragino Sans", "Hiragino Kaku Gothic ProN",
               "Noto Sans JP", Meiryo, sans-serif;
+            overflow-wrap: break-word;
           }
 
           .event_content_thumbnail {
@@ -162,6 +163,7 @@ export default defineComponent({
           .event_content_description {
             width: 100%;
             margin-top: 10px;
+            overflow-wrap: break-word;
           }
         }
       }
@@ -226,6 +228,7 @@ export default defineComponent({
             padding-right: 5px;
             font-family: YakuHanJP, "Hiragino Sans", "Hiragino Kaku Gothic ProN",
               "Noto Sans JP", Meiryo, sans-serif;
+            overflow-wrap: break-word;
           }
 
           .event_content_thumbnail {
@@ -247,6 +250,7 @@ export default defineComponent({
             width: 100%;
             margin-top: 10px;
             font-size: 0.8em;
+            overflow-wrap: break-word;
           }
         }
       }

--- a/front/components/EventHeld.vue
+++ b/front/components/EventHeld.vue
@@ -41,10 +41,15 @@ export default defineComponent({
       if (!props.startedAt || props.startedAt === "") return ""
       if (!props.endedAt || props.endedAt === "") return ""
 
+      const now = new Date()
       const eventStartDate = new Date(props.startedAt)
       const eventEndDate = new Date(props.endedAt)
+      const nextDate = (() => {
+        const date = new Date(now.getTime())
+        date.setDate(date.getDate() + 1)
+        return date
+      })()
 
-      const now = new Date()
       let eventStartStatusStyle
       let eventStartStatusLabel
       if (now >= eventStartDate && now <= eventEndDate) {
@@ -58,6 +63,14 @@ export default defineComponent({
       ) {
         eventStartStatusStyle = "event_status_today"
         eventStartStatusLabel = "本日開催"
+      } else if (
+        now < eventStartDate &&
+        nextDate.getFullYear() === eventStartDate.getFullYear() &&
+        nextDate.getMonth() === eventStartDate.getMonth() &&
+        nextDate.getDate() === eventStartDate.getDate()
+      ) {
+        eventStartStatusStyle = "event_status_tomorrow"
+        eventStartStatusLabel = "明日開催"
       } else if (now < eventStartDate) {
         eventStartStatusStyle = "event_status_preparation"
         eventStartStatusLabel = "開催前"
@@ -121,6 +134,10 @@ export default defineComponent({
       background-color: #f47721;
     }
 
+    .event_status_tomorrow {
+      background-color: #8560a8;
+    }
+
     .event_status_progress {
       background-color: #fd5c63;
     }
@@ -173,6 +190,10 @@ export default defineComponent({
 
     .event_status_today {
       background-color: #f47721;
+    }
+
+    .event_status_tomorrow {
+      background-color: #8560a8;
     }
 
     .event_status_progress {

--- a/front/components/EventHeld.vue
+++ b/front/components/EventHeld.vue
@@ -42,7 +42,7 @@ export default defineComponent({
       if (!props.endedAt || props.endedAt === "") return ""
 
       const eventStartDate = new Date(props.startedAt)
-      const eventEndDate = new Date(props.startedAt)
+      const eventEndDate = new Date(props.endedAt)
 
       const now = new Date()
       let eventStartStatusStyle

--- a/front/components/EventSortFilter.vue
+++ b/front/components/EventSortFilter.vue
@@ -193,6 +193,10 @@ export default defineComponent({
         display: flex;
         flex-direction: column;
 
+        select {
+          background-color: #ffffff;
+        }
+
         .event-modal-label {
           height: 40%;
           width: 100%;
@@ -296,6 +300,10 @@ export default defineComponent({
         display: flex;
         flex-direction: column;
         align-items: flex-start;
+
+        select {
+          background-color: #ffffff;
+        }
 
         .event-modal-label {
           height: 40%;

--- a/front/components/EventsHeader.vue
+++ b/front/components/EventsHeader.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
 .event_list_header
   .event_header_top
-    .event_header_info(v-if="$device.isDesktop")
+    .event_header_info
       | 友達からのイベント情報
     .event_sort_filter_button#js-event-sort-filter
       EventSortFilter(:eventSortType="eventSortType" :timeFilterType="timeFilterType" :friendsFilterType="friendsFilterType")
@@ -111,6 +111,7 @@ export default defineComponent({
         margin-right: auto;
         font-size: 1em;
         font-weight: bold;
+        display: none;
       }
 
       .event_sort_filter_button {

--- a/front/components/FriendsList.vue
+++ b/front/components/FriendsList.vue
@@ -269,9 +269,9 @@ export default defineComponent({
 
   .friends_list {
     width: 100%;
-    height: 80px;
     display: flex;
     flex-direction: row;
+    flex-wrap: wrap;
     align-items: center;
     justify-content: flex-start;
     padding: 20px 0;
@@ -284,7 +284,8 @@ export default defineComponent({
       background-color: #efe9e5;
       font-size: 1.5em;
       font-weight: bold;
-      margin-right: 10px;
+      margin-right: 5px;
+      margin-bottom: 5px;
       display: flex;
       flex-direction: row;
       justify-content: center;
@@ -298,6 +299,7 @@ export default defineComponent({
     .friend_icon {
       overflow: hidden;
       margin-right: 5px;
+      margin-bottom: 5px;
       cursor: pointer;
       width: 50px;
       height: 50px;
@@ -388,9 +390,9 @@ export default defineComponent({
 
   .friends_list {
     width: 100%;
-    height: 80px;
     display: flex;
     flex-direction: row;
+    flex-wrap: wrap;
     align-items: center;
     justify-content: flex-start;
     padding: 20px 0;
@@ -403,7 +405,8 @@ export default defineComponent({
       background-color: #efe9e5;
       font-size: 1em;
       font-weight: bold;
-      margin-right: 10px;
+      margin-right: 4px;
+      margin-bottom: 5px;
       display: flex;
       flex-direction: row;
       justify-content: center;
@@ -412,7 +415,8 @@ export default defineComponent({
     }
     .friend_icon {
       overflow: hidden;
-      margin-right: 5px;
+      margin-right: 4px;
+      margin-bottom: 5px;
       cursor: pointer;
       width: 30px;
       height: 30px;

--- a/front/components/Pagination.vue
+++ b/front/components/Pagination.vue
@@ -48,14 +48,6 @@ export default defineComponent({
         class: currentPage === 1 ? "click_disable" : ""
       })
 
-      if (currentPage > 1 + pageWindow) {
-        _pages.push({
-          label: "...",
-          value: "",
-          class: "intermediate_page click_disable"
-        })
-      }
-
       for (let page = currentPage - pageWindow; page < currentPage; page++) {
         if (page < 1) continue
 
@@ -83,14 +75,6 @@ export default defineComponent({
           label: page,
           value: page,
           class: "page_item"
-        })
-      }
-
-      if (currentPage < totalPages - pageWindow) {
-        _pages.push({
-          label: "...",
-          value: "",
-          class: "intermediate_page click_disable"
         })
       }
 

--- a/front/test/components/__snapshots__/Pagination.spec.ts.snap
+++ b/front/test/components/__snapshots__/Pagination.spec.ts.snap
@@ -9,7 +9,6 @@ exports[`Pagination.vue currentPage=2 1`] = `
     <li class=\\"current_page click_disable page_item\\">2</li>
     <li class=\\"page_item\\">3</li>
     <li class=\\"page_item\\">4</li>
-    <li class=\\"intermediate_page click_disable\\">...</li>
     <li class=\\"\\">次へ</li>
     <li class=\\"\\">最後</li>
   </ul>
@@ -26,7 +25,6 @@ exports[`Pagination.vue currentPage=3 1`] = `
     <li class=\\"current_page click_disable page_item\\">3</li>
     <li class=\\"page_item\\">4</li>
     <li class=\\"page_item\\">5</li>
-    <li class=\\"intermediate_page click_disable\\">...</li>
     <li class=\\"\\">次へ</li>
     <li class=\\"\\">最後</li>
   </ul>
@@ -38,13 +36,11 @@ exports[`Pagination.vue currentPage=4 1`] = `
   <ul>
     <li class=\\"\\">最初</li>
     <li class=\\"\\">前へ</li>
-    <li class=\\"intermediate_page click_disable\\">...</li>
     <li class=\\"page_item\\">2</li>
     <li class=\\"page_item\\">3</li>
     <li class=\\"current_page click_disable page_item\\">4</li>
     <li class=\\"page_item\\">5</li>
     <li class=\\"page_item\\">6</li>
-    <li class=\\"intermediate_page click_disable\\">...</li>
     <li class=\\"\\">次へ</li>
     <li class=\\"\\">最後</li>
   </ul>
@@ -56,13 +52,11 @@ exports[`Pagination.vue currentPage=10 1`] = `
   <ul>
     <li class=\\"\\">最初</li>
     <li class=\\"\\">前へ</li>
-    <li class=\\"intermediate_page click_disable\\">...</li>
     <li class=\\"page_item\\">8</li>
     <li class=\\"page_item\\">9</li>
     <li class=\\"current_page click_disable page_item\\">10</li>
     <li class=\\"page_item\\">11</li>
     <li class=\\"page_item\\">12</li>
-    <li class=\\"intermediate_page click_disable\\">...</li>
     <li class=\\"\\">次へ</li>
     <li class=\\"\\">最後</li>
   </ul>
@@ -74,13 +68,11 @@ exports[`Pagination.vue currentPage=97 1`] = `
   <ul>
     <li class=\\"\\">最初</li>
     <li class=\\"\\">前へ</li>
-    <li class=\\"intermediate_page click_disable\\">...</li>
     <li class=\\"page_item\\">95</li>
     <li class=\\"page_item\\">96</li>
     <li class=\\"current_page click_disable page_item\\">97</li>
     <li class=\\"page_item\\">98</li>
     <li class=\\"page_item\\">99</li>
-    <li class=\\"intermediate_page click_disable\\">...</li>
     <li class=\\"\\">次へ</li>
     <li class=\\"\\">最後</li>
   </ul>
@@ -92,7 +84,6 @@ exports[`Pagination.vue currentPage=98 1`] = `
   <ul>
     <li class=\\"\\">最初</li>
     <li class=\\"\\">前へ</li>
-    <li class=\\"intermediate_page click_disable\\">...</li>
     <li class=\\"page_item\\">96</li>
     <li class=\\"page_item\\">97</li>
     <li class=\\"current_page click_disable page_item\\">98</li>
@@ -109,7 +100,6 @@ exports[`Pagination.vue currentPage=99 1`] = `
   <ul>
     <li class=\\"\\">最初</li>
     <li class=\\"\\">前へ</li>
-    <li class=\\"intermediate_page click_disable\\">...</li>
     <li class=\\"page_item\\">97</li>
     <li class=\\"page_item\\">98</li>
     <li class=\\"current_page click_disable page_item\\">99</li>
@@ -125,7 +115,6 @@ exports[`Pagination.vue currentPage=100 1`] = `
   <ul>
     <li class=\\"\\">最初</li>
     <li class=\\"\\">前へ</li>
-    <li class=\\"intermediate_page click_disable\\">...</li>
     <li class=\\"page_item\\">98</li>
     <li class=\\"page_item\\">99</li>
     <li class=\\"current_page click_disable page_item\\">100</li>


### PR DESCRIPTION
# 内容

- [x] fix: SP版のページャーのウィンドウ幅が1だとレイアウトが崩れる
- [x] fix: イベント開催中のステータスにならない #439 
- [x] ソート&絞り込みUIのセレクタの背景色がグレーになる #436
- [x] fix: SP版で友達からのイベント情報が消えない #445]fix: イベントの友達数が多いと友達アイコンが潰れる #446
- [x] fix: イベントの友達数が多いと友達アイコンが潰れる #446
- [x] fix: SP版のイベント一覧でリンク付きのテキストがイベントのレイアウトをはみ出す #435 
- [x] feat: 明日開催のステータス表記を追加する #448