### PR TITLE
fix: ヘッダーのmarginとコンテンツのmarginを合わせる #453

### DIFF
--- a/front/layouts/authorized_default.vue
+++ b/front/layouts/authorized_default.vue
@@ -169,12 +169,11 @@ body {
 
 @media all and (max-width: 480px) {
   .header {
-    padding: 0 5px;
     background-color: #efe9e5;
 
     .header-container {
       margin: 0 auto;
-      padding: 0 5px;
+      padding: 0 20px;
       height: 56px;
       display: flex;
       flex-direction: row;


### PR DESCRIPTION
# 関連issue

#453