### PR TITLE
fix: イベント一覧の上部の余白を調整 #472 [ci skip]

### DIFF
--- a/front/pages/events.vue
+++ b/front/pages/events.vue
@@ -188,7 +188,7 @@ export default defineComponent({
     margin: 0 auto;
     margin-top: 20px;
     margin-bottom: 20px;
-    padding: 20px 0;
+    padding: 0 0 20px;
     border-radius: 5px;
     box-sizing: border-box;
     -moz-box-sizing: border-box;


### PR DESCRIPTION
# 関連issue

#472 
