### PR TITLE
Release-20210513

### DIFF
--- a/front/components/Event.vue
+++ b/front/components/Event.vue
@@ -150,7 +150,7 @@ export default defineComponent({
 
           .event_content_description {
             width: 100%;
-            margin-top: 10px;
+            margin-top: 5px;
             overflow-wrap: break-word;
           }
 
@@ -236,7 +236,7 @@ export default defineComponent({
 
           .event_content_description {
             width: 100%;
-            margin-top: 10px;
+            margin-top: 5px;
             font-size: 0.8em;
             overflow-wrap: break-word;
           }

--- a/front/components/EventHeld.vue
+++ b/front/components/EventHeld.vue
@@ -112,7 +112,6 @@ export default defineComponent({
       flex-direction: row;
       justify-content: center;
       align-items: center;
-      padding-top: 5px;
 
       span {
         margin: 0 2px;
@@ -171,7 +170,6 @@ export default defineComponent({
       flex-direction: row;
       justify-content: center;
       align-items: center;
-      padding-top: 5px;
 
       span {
         margin: 0 2px;

--- a/front/components/EventsHeader.vue
+++ b/front/components/EventsHeader.vue
@@ -100,7 +100,6 @@ export default defineComponent({
   .event_list_header {
     display: flex;
     flex-direction: column;
-    margin-bottom: 10px;
     .event_header_top {
       display: flex;
       flex-direction: row;
@@ -146,8 +145,8 @@ export default defineComponent({
       display: flex;
       flex-direction: row;
       justify-content: flex-end;
-      margin-bottom: 1rem;
-      margin-top: 1rem;
+      margin-bottom: 20px;
+      margin-top: 20px;
     }
   }
 }

--- a/front/components/FriendsList.vue
+++ b/front/components/FriendsList.vue
@@ -272,6 +272,7 @@ export default defineComponent({
     justify-content: flex-start;
     padding: 20px 0;
     box-sizing: border-box;
+    margin-bottom: -5px;
     .friend_number {
       width: 50px;
       height: 50px;
@@ -392,8 +393,9 @@ export default defineComponent({
     flex-wrap: wrap;
     align-items: center;
     justify-content: flex-start;
-    padding: 20px 0;
+    padding: 20px 0 0;
     box-sizing: border-box;
+    margin-bottom: -5px;
     .friend_number {
       width: 30px;
       height: 30px;

--- a/front/pages/events.vue
+++ b/front/pages/events.vue
@@ -188,7 +188,7 @@ export default defineComponent({
     margin: 0 auto;
     margin-top: 20px;
     margin-bottom: 20px;
-    padding: 20px 0;
+    padding: 0 0 20px;
     border-radius: 5px;
     box-sizing: border-box;
     -moz-box-sizing: border-box;


### PR DESCRIPTION
# 内容

- [x] イベント一覧の上部の余白を調整 #472 [ci skip]
- [x] fix: イベント一覧の上部の余白を調整 #477 
- [x] fix: イベント一覧の余白のリズムを統一する #473 
- [x] fix: 本文とタイトルのマージンを調整する #471 
- [x] fix: イベントカードの余白の調整 #468 
- [x] fix: イベント日付が下寄りになっている #469