### PR TITLE
fix: privateRuntimeConfig経由でCookieの鍵を設定するように修正

### DIFF
--- a/front/components/HomeTwitterLogin.vue
+++ b/front/components/HomeTwitterLogin.vue
@@ -89,7 +89,7 @@ export default defineComponent({
               store.commit("setAuth", auth)
 
               const { encryptCookieValue } = useCookieCryptoHelper()
-              Cookie.set("auth", encryptCookieValue(JSON.stringify(auth), root.$config.cookieSecret), { expires: 365, secure: process.env.NODE_ENV !== 'development' })
+              Cookie.set("auth", encryptCookieValue(JSON.stringify(auth), store.state.cookieSecret), { expires: 365, secure: process.env.NODE_ENV !== 'development' })
               root.$router.replace("/events")
             })
             .catch((error) => {

--- a/front/nuxt.config.js
+++ b/front/nuxt.config.js
@@ -87,7 +87,7 @@ export default {
       }
     }
   },
-  publicRuntimeConfig: {
+  privateRuntimeConfig: {
     cookieSecret: COOKIE_SECRET
   },
   env: {

--- a/front/store/index.ts
+++ b/front/store/index.ts
@@ -2,12 +2,17 @@ const cookieParser = process.server ? require("cookieparser") : undefined
 import { useCookieCryptoHelper } from "@/compositions/cookie_crypto_helper"
 
 export const state = () => ({
-  auth: null
+  auth: null,
+  cookieSecret: null
 })
 
 export const mutations = {
   setAuth(state: { auth: string }, auth: string) {
     state.auth = auth
+  },
+
+  setCookieSecret(state: { cookieSecret: string }, cookieSecret: string) {
+    state.cookieSecret = cookieSecret
   }
 }
 
@@ -27,5 +32,6 @@ export const actions = {
       }
     }
     commit("setAuth", auth)
+    commit("setCookieSecret", $config.cookieSecret)
   }
 }


### PR DESCRIPTION
# 内容

publicRuntimeConfig経由でCookieの鍵を渡すように設定していたが、privateRuntimeConfig経由で渡すように修正した。