### PR TITLE
fix: フロントとバックエンドのデフォルトのREADMEを修正

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -1,24 +1,14 @@
-# README
+# イベントフォローのバックエンド(Rails APIサーバ)
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+詳細は、[こちら](https://github.com/mh-mobile/event_follow/blob/develop/README.md)を参照してください。
 
-Things you may want to cover:
+# Author
 
-* Ruby version
+* [Github](https://github.com/mh-mobile)
+* [Qiita](https://qiita.com/mh_mobiler)
+* [Twitter](https://twitter.com/mh_mobiler)
 
-* System dependencies
+# ライセンス
 
-* Configuration
+本ソフトウェアは、MITライセンスの元提供されています。
 
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...

--- a/front/README.md
+++ b/front/README.md
@@ -1,20 +1,14 @@
-# front
+# イベントフォローのフロントエンド(Nuxt.js)
 
-## Build Setup
+詳細は、[こちら](https://github.com/mh-mobile/event_follow/blob/develop/README.md)を参照してください。
 
-```bash
-# install dependencies
-$ yarn install
+# Author
 
-# serve with hot reload at localhost:3000
-$ yarn dev
+* [Github](https://github.com/mh-mobile)
+* [Qiita](https://qiita.com/mh_mobiler)
+* [Twitter](https://twitter.com/mh_mobiler)
 
-# build for production and launch server
-$ yarn build
-$ yarn start
+# ライセンス
 
-# generate static project
-$ yarn generate
-```
+本ソフトウェアは、MITライセンスの元提供されています。
 
-For detailed explanation on how things work, check out [Nuxt.js docs](https://nuxtjs.org).


### PR DESCRIPTION
# 内容

フロントとバックエンドのREADMEが初期リポジトリ作成時のものなので、上位のREADMEを参照するようにREADMEを更新した。