### PR TITLE
APIコントローラのApiの頭字語をAPIに変更

### DIFF
--- a/api/app/controllers/api/base_controller.rb
+++ b/api/app/controllers/api/base_controller.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-class Api::BaseController < ApplicationController
+class API::BaseController < ApplicationController
 end

--- a/api/app/controllers/api/events_controller.rb
+++ b/api/app/controllers/api/events_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Api::EventsController < Api::BaseController
+class API::EventsController < API::BaseController
   before_action :set_sort_filter_condition
 
   def index

--- a/api/app/controllers/api/following_tweets_controller.rb
+++ b/api/app/controllers/api/following_tweets_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Api::FollowingTweetsController < Api::BaseController
+class API::FollowingTweetsController < API::BaseController
   def index
     @tweets = Tweet.tweets_for_event(params[:event_id])
                    .following_tweets(current_user).preload(:user)

--- a/api/app/controllers/api/friendships_controller.rb
+++ b/api/app/controllers/api/friendships_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Api::FriendshipsController < Api::BaseController
+class API::FriendshipsController < API::BaseController
   def index
     @users = User.where(id: find_user_ids)
   end

--- a/api/app/controllers/api/sessions_controller.rb
+++ b/api/app/controllers/api/sessions_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Api::SessionsController < Api::BaseController
+class API::SessionsController < API::BaseController
   skip_before_action :authenticate_user
 
   def create

--- a/api/app/controllers/api/users_controller.rb
+++ b/api/app/controllers/api/users_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Api::UsersController < Api::BaseController
+class API::UsersController < API::BaseController
   def destroy
     delete_user_session
     head :no_content

--- a/api/config/initializers/inflections.rb
+++ b/api/config/initializers/inflections.rb
@@ -1,17 +1,5 @@
 # frozen_string_literal: true
-# Be sure to restart your server when you modify this file.
 
-# Add new inflection rules using the following format. Inflections
-# are locale specific, and you may define rules for as many different
-# locales as you wish. All of these examples are active by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.plural /^(ox)$/i, '\1en'
-#   inflect.singular /^(ox)en/i, '\1'
-#   inflect.irregular 'person', 'people'
-#   inflect.uncountable %w( fish sheep )
-# end
-
-# These inflection rules are supported but not enabled by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.acronym 'RESTful'
-# end
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym "API"
+end


### PR DESCRIPTION
# 概要

以下のApiの頭字語をAPIに変更する。

https://github.com/mh-mobile/event_follow/blob/dd501d169794765c81b19003fc4a4b43f962490c/api/app/controllers/api/base_controller.rb#L3


# 関連issue

#518 