### PR TITLE
モデルのbelongs_toに指定したid属性のpresenceのバリデーションを削除

### DIFF
--- a/api/app/models/crawl_tweet.rb
+++ b/api/app/models/crawl_tweet.rb
@@ -3,7 +3,6 @@
 class CrawlTweet < ApplicationRecord
   belongs_to :user
 
-  validates :user_id, presence: true
   validates :text, presence: true
   validates :tweeted_at, presence: true
 end

--- a/api/app/models/event.rb
+++ b/api/app/models/event.rb
@@ -21,7 +21,6 @@ class Event < ActiveRecord::Base
      scope.order(Arel.sql(Event.event_sort_condition(user_event_setting.event_sort_type)))
    }
 
-  validates :site_id, presence: true
   validates :site_event_id, presence: true
   validates :title, presence: true
   validates :started_at, presence: true

--- a/api/app/models/friendship.rb
+++ b/api/app/models/friendship.rb
@@ -3,7 +3,4 @@
 class Friendship < ActiveRecord::Base
   belongs_to :follower, class_name: "User"
   belongs_to :followed, class_name: "User"
-
-  validates :follower_id, presence: true
-  validates :followed_id, presence: true
 end

--- a/api/app/models/tweet.rb
+++ b/api/app/models/tweet.rb
@@ -10,7 +10,6 @@ class Tweet < ApplicationRecord
   scope :following_tweets, -> (user) { where(user_id: user.following.ids) }
   scope :normal_tweets, -> { where(quoted_tweet_id: nil, retweeted_tweet_id: nil) }
 
-  validates :user_id, presence: true
   validates :event_id, presence: true
   validates :text, presence: true
   validates :tweeted_at, presence: true


### PR DESCRIPTION
# 概要

belongs_toに指定している属性はデフォルトで必須のため、presenceのバリデーションを実施する必要はない。
そのため、belongs_toに指定している属性のpresenceのバリデーション箇所を削除する。

https://github.com/mh-mobile/event_follow/blob/dd501d169794765c81b19003fc4a4b43f962490c/api/app/models/friendship.rb#L7-L8

# 参考

* belongs_toのrequiredの仕様
```
:required
When set to true, the association will also have its presence validated. This will validate the association itself, not the id. You can use :inverse_of to avoid an extra query during validation. NOTE: required is set to true by default and is deprecated. If you don't want to have association presence validated, use optional: true.
```
ref. [https://api.rubyonrails.org/v6.1.3.2/classes/ActiveRecord/Associations/ClassMethods.html#method-i-belongs_to](https://api.rubyonrails.org/v6.1.3.2/classes/ActiveRecord/Associations/ClassMethods.html#method-i-belongs_to)


# 関連issue

#520 