### PR TITLE
コントローラのEventモデルの変換処理をEventモデルに移植

### DIFF
--- a/api/app/controllers/api/events_controller.rb
+++ b/api/app/controllers/api/events_controller.rb
@@ -6,19 +6,7 @@ class Api::EventsController < Api::BaseController
   def index
     @events = Event.following_events(current_user).page(params[:page]).preload(tweets: :user)
     following = current_user.following.ids
-
-    @data = @events.map.with_index do |event, index|
-      friend_user_ids = event.tweets.pluck(:user_id).uniq.select do |user_id|
-        following.include?(user_id)
-      end
-      {
-        event: event,
-        extra: {
-          user_ids: friend_user_ids.join(","),
-          friends_number: friend_user_ids.length
-        }
-      }
-    end
+    @data = Event.convert_events(@events, following)
   end
 
   private

--- a/api/app/models/event.rb
+++ b/api/app/models/event.rb
@@ -27,4 +27,23 @@ class Event < ActiveRecord::Base
   validates :started_at, presence: true
   validates :ended_at, presence: true
   validates :url, presence: true
+
+  def self.convert_events(events, following)
+    events.map(&converter(following))
+  end
+
+  def self.converter(following)
+    Proc.new do |event|
+      friend_user_ids = event.tweets.pluck(:user_id).uniq.select do |user_id|
+        following.include?(user_id)
+      end
+      {
+        event: event,
+        extra: {
+          user_ids: friend_user_ids.join(","),
+          friends_number: friend_user_ids.length
+        }
+      }
+    end
+  end
 end


### PR DESCRIPTION
# 概要

コントローラ内部でモデルの変換処理を行なっているため、変換処理のロジックをモデルクラスに移植する。

https://github.com/mh-mobile/event_follow/blob/dd501d169794765c81b19003fc4a4b43f962490c/api/app/controllers/api/events_controller.rb#L10-L21

# 対応内容

Eventクラスに変換用のクラスメソッドを追加し、そのクラスメソッドでモデルの変換処理を実施するようにした。

# 関連issue

#519 