### PR TITLE
GitHub Actionsのreviewdog_rubocopアクションのGem::FilePermissionError対応

### DIFF
--- a/.github/workflows/api_lint.yml
+++ b/.github/workflows/api_lint.yml
@@ -11,12 +11,14 @@ jobs:
   reviewdog_rubocop:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v1
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.0.0
       - name: rubocop
         uses: reviewdog/action-rubocop@v1
         with:
-          rubocop_version: 1.8.1
+          rubocop_version: 1.11.0
           github_token: ${{ secrets.GITHUB_TOKEN }}
           rubocop_flags: --config api/.rubocop.yml api/
           reporter: github-pr-check
-


### PR DESCRIPTION
# 概要

reviewdog_rubocopアクションでGem::FilePermissionErrorが発生しているため、修正を行なった。

![image](https://user-images.githubusercontent.com/13811034/121309460-2c65f700-c93d-11eb-97c8-912614b892a2.png)

# 対応内容

- [x] ruby/setup-ruby@v1のアクションを追加
- [x] rubocop_versionをローカルのバージョンの1.11.0に変更
- [x] actions/checkoutのバージョンをv1に変更

# 参考

[reviewdog/action-rubocop実行時に起きたGem::FilePermissionErrorの対処](https://zenn.dev/m_yamashii/articles/bf6a52a71f887d)