### PR TITLE
Release-20210610

### DIFF
--- a/.github/workflows/api_lint.yml
+++ b/.github/workflows/api_lint.yml
@@ -11,12 +11,14 @@ jobs:
   reviewdog_rubocop:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v1
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.0.0
       - name: rubocop
         uses: reviewdog/action-rubocop@v1
         with:
-          rubocop_version: 1.8.1
+          rubocop_version: 1.11.0
           github_token: ${{ secrets.GITHUB_TOKEN }}
           rubocop_flags: --config api/.rubocop.yml api/
           reporter: github-pr-check
-

--- a/api/app/controllers/api/base_controller.rb
+++ b/api/app/controllers/api/base_controller.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-class Api::BaseController < ApplicationController
+class API::BaseController < ApplicationController
 end

--- a/api/app/controllers/api/events_controller.rb
+++ b/api/app/controllers/api/events_controller.rb
@@ -6,19 +6,7 @@ class API::EventsController < API::BaseController
   def index
     @events = Event.following_events(current_user).page(params[:page]).preload(tweets: :user)
     following = current_user.following.ids
-
-    @data = @events.map.with_index do |event, index|
-      friend_user_ids = event.tweets.pluck(:user_id).uniq.select do |user_id|
-        following.include?(user_id)
-      end
-      {
-        event: event,
-        extra: {
-          user_ids: friend_user_ids.join(","),
-          friends_number: friend_user_ids.length
-        }
-      }
-    end
+    @data = Event.convert_events(@events, following)
   end
 
   private

--- a/api/app/controllers/api/events_controller.rb
+++ b/api/app/controllers/api/events_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Api::EventsController < Api::BaseController
+class API::EventsController < API::BaseController
   before_action :set_sort_filter_condition
 
   def index

--- a/api/app/controllers/api/following_tweets_controller.rb
+++ b/api/app/controllers/api/following_tweets_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Api::FollowingTweetsController < Api::BaseController
+class API::FollowingTweetsController < API::BaseController
   def index
     @tweets = Tweet.tweets_for_event(params[:event_id])
                    .following_tweets(current_user).preload(:user)

--- a/api/app/controllers/api/friendships_controller.rb
+++ b/api/app/controllers/api/friendships_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Api::FriendshipsController < Api::BaseController
+class API::FriendshipsController < API::BaseController
   def index
     @users = User.where(id: find_user_ids)
   end

--- a/api/app/controllers/api/sessions_controller.rb
+++ b/api/app/controllers/api/sessions_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Api::SessionsController < Api::BaseController
+class API::SessionsController < API::BaseController
   skip_before_action :authenticate_user
 
   def create

--- a/api/app/controllers/api/users_controller.rb
+++ b/api/app/controllers/api/users_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Api::UsersController < Api::BaseController
+class API::UsersController < API::BaseController
   def destroy
     delete_user_session
     head :no_content

--- a/api/app/models/crawl_tweet.rb
+++ b/api/app/models/crawl_tweet.rb
@@ -3,7 +3,6 @@
 class CrawlTweet < ApplicationRecord
   belongs_to :user
 
-  validates :user_id, presence: true
   validates :text, presence: true
   validates :tweeted_at, presence: true
 end

--- a/api/app/models/event.rb
+++ b/api/app/models/event.rb
@@ -21,7 +21,6 @@ class Event < ActiveRecord::Base
      scope.order(Arel.sql(Event.event_sort_condition(user_event_setting.event_sort_type)))
    }
 
-  validates :site_id, presence: true
   validates :site_event_id, presence: true
   validates :title, presence: true
   validates :started_at, presence: true

--- a/api/app/models/event.rb
+++ b/api/app/models/event.rb
@@ -26,4 +26,23 @@ class Event < ActiveRecord::Base
   validates :started_at, presence: true
   validates :ended_at, presence: true
   validates :url, presence: true
+
+  def self.convert_events(events, following)
+    events.map(&converter(following))
+  end
+
+  def self.converter(following)
+    Proc.new do |event|
+      friend_user_ids = event.tweets.pluck(:user_id).uniq.select do |user_id|
+        following.include?(user_id)
+      end
+      {
+        event: event,
+        extra: {
+          user_ids: friend_user_ids.join(","),
+          friends_number: friend_user_ids.length
+        }
+      }
+    end
+  end
 end

--- a/api/app/models/friendship.rb
+++ b/api/app/models/friendship.rb
@@ -3,7 +3,4 @@
 class Friendship < ActiveRecord::Base
   belongs_to :follower, class_name: "User"
   belongs_to :followed, class_name: "User"
-
-  validates :follower_id, presence: true
-  validates :followed_id, presence: true
 end

--- a/api/app/models/tweet.rb
+++ b/api/app/models/tweet.rb
@@ -10,7 +10,6 @@ class Tweet < ApplicationRecord
   scope :following_tweets, -> (user) { where(user_id: user.following.ids) }
   scope :normal_tweets, -> { where(quoted_tweet_id: nil, retweeted_tweet_id: nil) }
 
-  validates :user_id, presence: true
   validates :event_id, presence: true
   validates :text, presence: true
   validates :tweeted_at, presence: true

--- a/api/config/initializers/inflections.rb
+++ b/api/config/initializers/inflections.rb
@@ -1,17 +1,5 @@
 # frozen_string_literal: true
-# Be sure to restart your server when you modify this file.
 
-# Add new inflection rules using the following format. Inflections
-# are locale specific, and you may define rules for as many different
-# locales as you wish. All of these examples are active by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.plural /^(ox)$/i, '\1en'
-#   inflect.singular /^(ox)en/i, '\1'
-#   inflect.irregular 'person', 'people'
-#   inflect.uncountable %w( fish sheep )
-# end
-
-# These inflection rules are supported but not enabled by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.acronym 'RESTful'
-# end
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym "API"
+end


### PR DESCRIPTION

# 内容

- [x] GitHub Actionsのreviewdog_rubocopアクションのGem::FilePermissionError対応 #524 
- [x] コントローラのEventモデルの変換処理をEventモデルに移植 #523 
- [x] モデルのbelongs_toに指定したid属性のpresenceのバリデーションを削除 #522 
- [x] APIコントローラのApiの頭字語をAPIに変更 #521
