### PR TITLE
フロントのコンソールエラーを修正

### DIFF
--- a/front/layouts/authorized_default.vue
+++ b/front/layouts/authorized_default.vue
@@ -35,7 +35,8 @@ export default defineComponent({
       return {
         currentUser: null,
         logout: null,
-        deleteAccount: null
+        deleteAccount: null,
+        goToSetting: null,
       }
     }
 


### PR DESCRIPTION
# 概要

Chrome DevToolsを見ると、フロントのコンソールエラーが発生しているので、修正を実施する。